### PR TITLE
Add ErrorTransThrow companion object

### DIFF
--- a/modules/core/project/build.properties
+++ b/modules/core/project/build.properties
@@ -1,1 +1,0 @@
-sbt.version=1.2.8


### PR DESCRIPTION
Add an ErrorTransThrow companion object to allow consumers to summon an
instance of ErrorTransThrow for EitherT and ZIO.