### PR TITLE
 Remove bifunctor from ErrorTrans

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -6,19 +6,17 @@ lazy val root = Project("hotpotato", file("."))
     commonSettings,
   )
 
-val zioDep             = "dev.zio" %% "zio" % "1.0.0-RC17"
-val zioCatsInteroptDep = "dev.zio" %% "zio-interop-cats" % "2.0.0.0-RC10"
-val catsEffectDep      = "org.typelevel" %% "cats-effect" % "2.0.0"
-val catsCoreDep        = "org.typelevel" %% "cats-core" % "2.0.0"
+val zioDep        = "dev.zio" %% "zio" % "1.0.0-RC17"
+val catsCoreDep   = "org.typelevel" %% "cats-core" % "2.0.0"
+val catsEffectDep = "org.typelevel" %% "cats-effect" % "2.0.0"
+
 lazy val core = moduleProject("core")
   .enablePlugins(BoilerplatePlugin)
   .settings(
     libraryDependencies ++= Seq(
       "com.chuusai" %% "shapeless" % "2.3.3",
       catsCoreDep,
-      catsEffectDep % "optional",
-      zioDep % "optional",
-      zioCatsInteroptDep % "optional",
+      zioDep % Optional,
       "org.typelevel" %% "cats-laws" % "2.0.0" % Test,
       "org.typelevel" %% "discipline-scalatest" % "1.0.0-RC1" % Test,
     ),
@@ -38,7 +36,6 @@ lazy val testoptionaldependency = moduleProject("testoptionaldependency")
     publish / skip := true,
     libraryDependencies ++= Seq(
       zioDep,
-      zioCatsInteroptDep,
       catsCoreDep,
       catsEffectDep,
     ),
@@ -52,8 +49,6 @@ lazy val docs = project
     publish / skip := true,
     libraryDependencies ++= Seq(
       zioDep,
-      zioCatsInteroptDep,
-      catsEffectDep,
     ),
   )
   .settings(

--- a/modules/core/project/build.properties
+++ b/modules/core/project/build.properties
@@ -1,1 +1,0 @@
-sbt.version=1.2.8

--- a/modules/core/src/main/boilerplate/hotpotato/ErrorTransSyntax.template
+++ b/modules/core/src/main/boilerplate/hotpotato/ErrorTransSyntax.template
@@ -1,9 +1,10 @@
 package hotpotato
+
+import cats.syntax.either._
+import hotpotato.coproduct.Unique
 import shapeless._
 import shapeless.ops.coproduct._
-import hotpotato.coproduct.Unique
 import shapeless.syntax.inject._
-import cats.implicits._
 
 trait ErrorTransSyntax {
   [#
@@ -14,7 +15,7 @@ trait ErrorTransSyntax {
     )(
       implicit errorTrans: ErrorTrans[F]
     ): F[OutL, R] = {
-      errorTrans.bifunctor.leftMap(in) {
+      errorTrans.mapError(in) {
         [1..#case [2..#Inr(# ]Inl(e)[2..#)# ] => func1(e)#
         ]
         case [1..#Inr(# ]e[1..#)# ] => e.impossible
@@ -28,7 +29,7 @@ trait ErrorTransSyntax {
       implicit unique: Unique[[#L1Out :+:# ] CNil],
       errorTrans: ErrorTrans[F]
     ): F[unique.Out, R] = {
-      errorTrans.bifunctor.leftMap(in) { err =>
+      errorTrans.mapError(in) { err =>
         type LOut = [#L1Out :+: # ] CNil
         err match {
           [1..#case [2..#Inr(# ]Inl(e)[2..#)# ] => unique(func1(e).inject[LOut])# ]
@@ -60,7 +61,7 @@ trait ErrorTransSyntax {
       errorTrans.flatMapError(in) { err =>
         type LOut = [#L1Out :+: # ] CNil
         err match {
-          [1..#case [2..#Inr(# ]Inl(e)[2..#)# ] => errorTrans.bifunctor.bimap(func1(e))(eOut => unique(eOut.inject[LOut]), identity)# ]
+          [1..#case [2..#Inr(# ]Inl(e)[2..#)# ] => errorTrans.mapError(func1(e))(eOut => unique(eOut.inject[LOut]))# ]
           case [1..#Inr(# ]e[1..#)# ] => e.impossible
         }
       }
@@ -78,7 +79,7 @@ trait ErrorTransSyntax {
       unique: Unique.Aux[[#L1Out# :+: ] :+: BasisRest, UniqueOut],
       errorTrans: ErrorTrans[F]
     ): F[UniqueOut, R] = {
-      errorTrans.bifunctor.leftMap(in) { err =>
+      errorTrans.mapError(in) { err =>
         unique.apply {
           basis(err) match {
             case Left(rest) => rest.extendLeftBy[[#L1Out# :+: ] :+: CNil]
@@ -111,7 +112,7 @@ trait ErrorTransSyntax {
           case Right(extracted) => {
             type LOut = [#L1Out# :+: ] :+: BasisRest
             extracted match {
-              [1..#case [2..#Inr(# ]Inl(e)[2..#)# ] => errorTrans.bifunctor.leftMap(func1(e))(
+              [1..#case [2..#Inr(# ]Inl(e)[2..#)# ] => errorTrans.mapError(func1(e))(
                 lxOut => unique.apply(Coproduct[LOut](lxOut)),
               )#
               ]
@@ -127,7 +128,7 @@ trait ErrorTransSyntax {
       implicit errorTrans: ErrorTrans[F],
       unifier: Unifier.Aux[L, UnifiedL]
     ): F[UnifiedL, R] = {
-      errorTrans.bifunctor.leftMap(in) { err =>
+      errorTrans.mapError(in) { err =>
         unifier(err)
       }
     }
@@ -166,7 +167,7 @@ trait ErrorTransSyntax {
     def errorAsCoproduct[LCopRepr <: Coproduct](
       implicit errorTrans: ErrorTrans[F],
         gen: Generic.Aux[L, LCopRepr]
-    ): F[LCopRepr, R] = errorTrans.bifunctor.leftMap(in)(l => gen.to(l))
+    ): F[LCopRepr, R] = errorTrans.mapError(in)(l => gen.to(l))
 
     @inline def errorIs[LL](
       implicit ev: L =:= LL

--- a/modules/core/src/main/scala/hotpotato/syntax/ErrorTransEmbedSyntax.scala
+++ b/modules/core/src/main/scala/hotpotato/syntax/ErrorTransEmbedSyntax.scala
@@ -16,7 +16,7 @@ private[hotpotato] trait ErrorTransEmbedSyntax {
       embedder: Embedder[Super],
       basis: Basis[Super, L],
     ): F[Super, R] =
-      F.bifunctor.leftMap(in) { err =>
+      F.mapError(in) { err =>
         embedder.embed[L](err)(basis)
       }
 
@@ -30,7 +30,7 @@ private[hotpotato] trait ErrorTransEmbedSyntax {
       embedder: Embedder[Super], // Used for type inference only
       inject: Inject[Super, L],
     ): F[Super, R] =
-      F.bifunctor.leftMap(in) { err =>
+      F.mapError(in) { err =>
         inject(err)
       }
   }

--- a/modules/core/src/test/scala/hotpotato/ErrorTransInstanceSpec.scala
+++ b/modules/core/src/test/scala/hotpotato/ErrorTransInstanceSpec.scala
@@ -14,12 +14,12 @@ class ErrorTransInstanceSpec extends AnyFunSuite with Discipline {
 
   checkAll(
     "Either.ErrorTransLaws",
-    ErrorTransTests[Either[*, *]].errorTrans[Int, Int, Int, String, String, String],
+    ErrorTransTests[Either[*, *]].errorTrans[Int, Int, Int, String],
   )
 
   checkAll(
     "EitherT.ErrorTransLaws",
-    ErrorTransTests[EitherT[Option, *, *]].errorTrans[Int, Int, Int, String, String, String],
+    ErrorTransTests[EitherT[Option, *, *]].errorTrans[Int, Int, Int, String],
   )
 
   // Cheat a little bit by only generating only one type of throwable
@@ -33,7 +33,7 @@ class ErrorTransInstanceSpec extends AnyFunSuite with Discipline {
   checkAll(
     "EitherT.ErrorTransThrowLaws",
     ErrorTransThrowTests[EitherT[Either[Throwable, *], *, *]]
-      .errorTransThrow[Int, Int, Int, String, String, String],
+      .errorTransThrow[Int, Int, Int, String],
   )
 }
 


### PR DESCRIPTION
As bifunctor on ErrorTrans is only used for `leftMap`, replace it with a new `mapError` function. This method can be implemented in terms of `pureError` and `flatMapError`.